### PR TITLE
Localization/add-spanish-spain

### DIFF
--- a/internal/ui.lua
+++ b/internal/ui.lua
@@ -211,7 +211,7 @@ Cartomancer.config_tab = function()
                         {n=G.UIT.R, config={align = "cm", minh = 1, padding = 0.1}, nodes={
                             {n=G.UIT.C, config={align = "cr", minw = 2, minh =1, r = 0.1,colour = G.C.UI_CHIPS, id = 'hand_chip_area_cart', emboss = 0.05}, nodes={
                                 {n=G.UIT.O, config={func = 'flame_handler',no_role = true, id = 'flame_chips_cart', object = Moveable(0,0,0,0), w = 0, h = 0}},
-                                {n=G.UIT.O, config={id = ':3_chips',object = DynaText({string = {{ref_table = {[":3"] = "Chips" }, ref_value = ":3"}}, colours = {G.C.UI.TEXT_LIGHT}, font = G.LANGUAGES['en-us'].font, shadow = true, float = true, scale = scale*2})}},
+                                {n=G.UIT.O, config={id = ':3_chips',object = DynaText({string = {{ref_table = {[":3"] = localize("carto_flames_chips") }, ref_value = ":3"}}, colours = {G.C.UI.TEXT_LIGHT}, font = G.LANGUAGES['en-us'].font, shadow = true, float = true, scale = scale*2})}},
                                 {n=G.UIT.B, config={w=0.1,h=0.1}},
                             }},
                             {n=G.UIT.C, config={align = "cm"}, nodes={
@@ -220,7 +220,7 @@ Cartomancer.config_tab = function()
                             {n=G.UIT.C, config={align = "cl", minw = 2, minh=1, r = 0.1,colour = G.C.UI_MULT, id = 'hand_mult_area_cart', emboss = 0.05}, nodes={
                                 {n=G.UIT.O, config={func = 'flame_handler',no_role = true, id = 'flame_mult_cart', object = Moveable(0,0,0,0), w = 0, h = 0}},
                                 {n=G.UIT.B, config={w=0.1,h=0.1}},
-                                {n=G.UIT.O, config={id = ':3_mult',object = DynaText({string = {{ref_table = {[":3"] = "Mult" }, ref_value = ":3"}}, colours = {G.C.UI.TEXT_LIGHT}, font = G.LANGUAGES['en-us'].font, shadow = true, float = true, scale = scale*2})}},
+                                {n=G.UIT.O, config={id = ':3_mult',object = DynaText({string = {{ref_table = {[":3"] = localize("carto_flames_mult") }, ref_value = ":3"}}, colours = {G.C.UI.TEXT_LIGHT}, font = G.LANGUAGES['en-us'].font, shadow = true, float = true, scale = scale*2})}},
                             }}
                         }},
                         create_inline_slider({align = 'cm', ref_table = Cartomancer, ref_value = '_INTERNAL_gasoline', localization = 'carto_flames_gasoline', max_value = Cartomancer._INTERNAL_max_flames_intensity, decimal_places = 1}),

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -39,6 +39,8 @@ return {
             carto_hide_deck = "Hide deck",
             carto_hide_jokers = "Hide jokers",
 
+            carto_flames_chips = "Chips",
+            carto_flames_mult = "Mult",
             carto_flames_intensity_min = "Min intensity ",
             carto_flames_intensity_max = "Max intensity ",
             carto_flames_relative_intensity = "Score intensity relative to current blind",

--- a/localization/es_ES.lua
+++ b/localization/es_ES.lua
@@ -1,0 +1,68 @@
+return {
+    misc = {
+      dictionary = {
+        carto_settings_compact_deck = "Baraja compacta",
+        carto_settings_deck_view = "Vista de la baraja",
+        carto_settings_jokers = "Comodines",
+        carto_settings_flames = "Llamas",
+        carto_settings_other = "Otros",
+        carto_settings_keybinds = "Teclas",
+        
+        carto_compact_deck_enabled = "Limitar cartas en el baraja",
+        carto_compact_deck_visible_cards = "Límite de cartas ",
+
+        carto_deck_view_stack_enabled = "Apilar cartas en la vista de la baraja",
+        carto_deck_view_hide_drawn_cards = "Ocultar cartas robadas",
+        carto_deck_view_stack_modifiers = "Apilar todos los modificadores",
+        carto_deck_view_stack_chips = "Apilar diferentes valores de fichas",
+
+        carto_deck_view_stack_x_color = "Color ",
+        carto_deck_view_stack_background_opacity = "Opacidad ",
+        carto_deck_view_stack_pos = "Alineación ",
+        carto_deck_view_stack_pos_vertical_options = {
+          "arriba",
+          "centro",
+          "abajo"
+        },
+        carto_deck_view_stack_pos_horizontal_options = {
+          "izquierda",
+          "medio",
+          "derecha"
+        },
+        carto_deck_view_unique_cards = "Cartas únicas:",
+        
+        carto_draw_non_essential_shaders = "Mostrar shaders no esenciales",
+        carto_improved_hand_sorting = "Ordenación mejorada de la mano",
+        carto_dynamic_hand_align = "Alineación mejorada para manos grandes",
+        carto_hide_tags = "Ocultar etiquetas",
+        carto_hide_consumables = "Ocultar consumibles",
+        carto_hide_deck = "Ocultar baraja",
+        carto_hide_jokers = "Ocultar comodines",
+      
+        carto_flames_chips = "Fichas",
+        carto_flames_mult = "Multi",
+        carto_flames_intensity_min = "Intensidad mínima ",
+        carto_flames_intensity_max = "Intensidad máxima ",
+        carto_flames_relative_intensity = "Intensidad relativa a la ciega actual",
+        carto_flames_intensity_vanilla = "Ignorar intensidad mín/máx",
+        carto_flames_gasoline_title = "Vista previa",
+        carto_flames_gasoline = "",
+        carto_flames_volume = "Volumen de llamas ",
+
+        carto_jokers_controls_buttons = "Mostrar botones del área de comodines",
+        carto_jokers_controls_show_after = "Después de tener más de: ",
+
+        carto_jokers_hide = "Ocultar",
+        carto_jokers_show = "Mostrar",
+        carto_jokers_zoom = "Ampliar",
+
+        carto_waiting_keybind = "Esperando entrada...",
+        carto_kb_hide_joker = "Ocultar comodín",
+        carto_kb_toggle_tags = "Alternar visibilidad de etiquetas",
+        carto_kb_toggle_consumables = "Alternar visibilidad de consumibles",
+        carto_kb_toggle_jokers = "Alternar visibilidad de comodines",
+        carto_kb_toggle_jokers_buttons = "Alternar botones de comodines",
+      }
+    }
+  }
+  


### PR DESCRIPTION
Adds Spanish localization (`es_ES.lua`) and includes localization for "chips" and "mult" in `ui.lua`. Additionally, the corresponding entries for "chips" and "mult" have been added to `en-us.lua`.

⚠️ Bug Report:

While testing the Spanish localization changes introduced in this PR, I noticed a bug in the alignment settings under `Configuration > Deck View > Alignment`. When the language is set to Spanish, the alignment options ("Bottom", "Center", "Top", etc.) do not work correctly. This issue does not occur when the language is set to English.

Steps to reproduce:
1. Set the application language to Spanish (es_ES).
2. Go to `Configuration > Deck View > Alignment`.
3. Try changing the alignment options.
4. Observe that they do not respond correctly.

Expected behavior:
The alignment settings should work consistently across all languages.

This issue might be related to changes in `es_ES.lua` or how localized strings are handled in `ui.lua`. Further investigation is required.



https://github.com/user-attachments/assets/558c2132-869c-411e-8d0b-30451afc7dfc