### PR TITLE
Add new localization strings for the Chinese translation.

### DIFF
--- a/localization/zh_CN.lua
+++ b/localization/zh_CN.lua
@@ -71,8 +71,8 @@ return {
             carto_score_highest = "最高得分",
             carto_score_last = "上一次出牌",
 
-            carto_peek_shop_setting = "从补充包中预览商店",
-            carto_peek_shop_1 = "预览",
+            carto_peek_shop_setting = "从补充包中查看商店内容",
+            carto_peek_shop_1 = "查看",
             carto_peek_shop_2 = "商店",
             carto_peek_shop_vanilla_label = "商店",
         }


### PR DESCRIPTION
Update Chinese localization (zh_CN.lua)

- Add missing localization keys from en-us.lua:
  - carto_deck_view_stack_compact
  - carto_jokers_jiggle
  - carto_highlight_played_hands
  - carto_score_highest, carto_score_last
  - carto_peek_shop_setting, carto_peek_shop_1, carto_peek_shop_2, carto_peek_shop_vanilla_label


**Suggestion for score area icons** (`carto_score_highest` and `carto_score_last`):
Currently using hardcoded red stake icons. I think it would be better either:
1. Use dynamic stake icons based on current run's stake level, or
2. Use the UI icon like vanilla game uses for "best hand" in Stats tab (first icon in ui_assets.png).

<img width="515" height="195" alt="image" src="https://github.com/user-attachments/assets/4f9a4d58-231f-4b5d-a087-df13d584b9a0" />
<img width="510" height="83" alt="image" src="https://github.com/user-attachments/assets/ad4bb61d-2a6f-49e5-bbe2-e20e1dccc59c" />

